### PR TITLE
[Issue #27] hardware task manager receives dest mac from job manager

### DIFF
--- a/platform/hardware/xilinx/modules/data_router/data_router.cpp
+++ b/platform/hardware/xilinx/modules/data_router/data_router.cpp
@@ -91,7 +91,7 @@ void data_router(stream<axiWord>                &rxDataIn,
             if (!rxDataIn.empty() && !dest_mac.full()) {
                 axiWord word = rxDataIn.read();
                 dest_mac_second = word.data.range(15, 0);
-                dest_mac.write((dest_mac_first, dest_mac_second));
+                dest_mac.write((dest_mac_second, dest_mac_first));
                 rxState = MYSTR_RX_TM_WAIT;
             }
             break;

--- a/platform/software/bin/FPGAOperators.py
+++ b/platform/software/bin/FPGAOperators.py
@@ -12,10 +12,10 @@ class SendOperator(OperatorInterface, BaseOperator):
         self.count = 0
     
     def run(self):
-        if not self.out_streams[0].full():
-            message = struct.pack('<Q', self.count)
-            self.out_streams[0].put(message)
-            self.count += 2
+        #if not self.out_streams[0].full():
+        message = struct.pack('<Q', self.count)
+        self.out_streams[0].put(message)
+        self.count += 2
 
     def pause(self):
         pass
@@ -30,11 +30,11 @@ class IncrementOperator(OperatorInterface, BaseOperator):
         pass
     
     def run(self):
-        if not self.out_streams[0].full():
-            if not self.in_streams[0].empty():
-                event = self.in_streams[0].get()
-                event += 1
-                self.out_streams[0].put(event)
+        #if not self.out_streams[0].full():
+        #    if not self.in_streams[0].empty():
+        event = self.in_streams[0].get()
+        event += 1
+        self.out_streams[0].put(event)
     
     def pause(self):
         pass
@@ -51,11 +51,11 @@ class ReceiveOperator(OperatorInterface, BaseOperator):
         f.close()
     
     def run(self):
-        if not self.in_streams[0].empty():
-            event = struct.unpack('<Q', self.in_streams[0].get())
-            f = open(self.file_name, 'a')
-            f.write(str(event) + '\n')
-            f.close()
+        #if not self.in_streams[0].empty():
+        event = struct.unpack('<Q', self.in_streams[0].get())
+        f = open(self.file_name, 'a')
+        f.write(str(event) + '\n')
+        f.close()
     
     def pause(self):
         pass


### PR DESCRIPTION
The mac address given from job manager to task manager was not properly set to the variable that is written to the tx buffer. Fixed.